### PR TITLE
Add CW_IN_REG_STI module

### DIFF
--- a/files/sources/CW_IN_REG_STI.v
+++ b/files/sources/CW_IN_REG_STI.v
@@ -1,0 +1,63 @@
+`timescale 1ns / 1ps
+//////////////////////////////////////////////////////////////////////////////////
+// Company: 
+// Engineer: 
+// 
+// Create Date: 26.04.2026 18:40:28
+// Design Name: 
+// Module Name: CW_IN_REG_STI
+// Project Name: 
+// Target Devices: 
+// Tool Versions: 
+// Description: 
+// 
+// Dependencies: 
+// 
+// Revision:
+// Revision 0.01 - File Created
+// Additional Comments:
+// 
+//////////////////////////////////////////////////////////////////////////////////
+
+module CW_IN_REG_STI (
+    input  wire        CLK,
+    input  wire        RST,
+    input  wire  [7:0] IN,
+
+    //Сигналы протокола STI 1.0 (не используются)
+    input  wire  [7:0] S_D_WR,     
+    input  wire  [2:0] S_CMD,     
+    input  wire        S_EX_REQ,   
+
+    output wire  [7:0] S_D_RD,
+    output wire        S_EX_ACK
+);
+
+    // Внутренние регистры для цепочки синхронизации
+    reg [7:0] sync_stage_1;
+    reg [7:0] sync_stage_2;
+
+    always @(posedge CLK) begin
+        if (RST) begin
+            sync_stage_1 <= 8'b0;
+        end else begin
+            sync_stage_1 <= IN;
+        end
+    end
+
+    always @(posedge CLK) begin
+        if (RST) begin
+            sync_stage_2 <= 8'b0;
+        end else begin
+            sync_stage_2 <= sync_stage_1;
+        end
+    end
+
+    assign S_D_RD = sync_stage_2;
+    assign S_EX_ACK = 1'b1;
+
+    //Предотвращение предупреждений компилятора о неиспользуемых входах
+    wire unused_inputs_check;
+    assign unused_inputs_check = &{S_D_WR, S_CMD, S_EX_REQ}; 
+
+endmodule

--- a/files/sources/CW_IN_REG_STI.v
+++ b/files/sources/CW_IN_REG_STI.v
@@ -1,7 +1,7 @@
 `timescale 1ns / 1ps
 //////////////////////////////////////////////////////////////////////////////////
 // Company: 
-// Engineer: 
+// Engineer: Semenikhin A.V.
 // 
 // Create Date: 26.04.2026 18:40:28
 // Design Name: 
@@ -9,7 +9,7 @@
 // Project Name: 
 // Target Devices: 
 // Tool Versions: 
-// Description: 
+// Description: Operator's Register
 // 
 // Dependencies: 
 // 
@@ -24,7 +24,7 @@ module CW_IN_REG_STI (
     input  wire        RST,
     input  wire  [7:0] IN,
 
-    //Сигналы протокола STI 1.0 (не используются)
+    //Unused STI 1.0 Ports
     input  wire  [7:0] S_D_WR,     
     input  wire  [2:0] S_CMD,     
     input  wire        S_EX_REQ,   
@@ -33,22 +33,21 @@ module CW_IN_REG_STI (
     output wire        S_EX_ACK
 );
 
-    // Внутренние регистры для цепочки синхронизации
+    //Chain of registers
     reg [7:0] sync_stage_1;
     reg [7:0] sync_stage_2;
 
-    always @(posedge CLK) begin
-        if (RST) begin
-            sync_stage_1 <= 8'b0;
-        end else begin
-            sync_stage_1 <= IN;
-        end
+    initial begin
+        sync_stage_1 = 8'h00;
+        sync_stage_2 = 8'h00;
     end
 
-    always @(posedge CLK) begin
+    always @(posedge CLK, posedge RST) begin
         if (RST) begin
-            sync_stage_2 <= 8'b0;
+            sync_stage_1 <= 8'h00;
+            sync_stage_2 <= 8'h00;
         end else begin
+            sync_stage_1 <= IN;
             sync_stage_2 <= sync_stage_1;
         end
     end
@@ -56,8 +55,5 @@ module CW_IN_REG_STI (
     assign S_D_RD = sync_stage_2;
     assign S_EX_ACK = 1'b1;
 
-    //Предотвращение предупреждений компилятора о неиспользуемых входах
-    wire unused_inputs_check;
-    assign unused_inputs_check = &{S_D_WR, S_CMD, S_EX_REQ}; 
 
 endmodule


### PR DESCRIPTION
Operands A & B Register module. Contains unreadable comments indicative of unused STI 1.0 signals. Closes #24 .