### PR TITLE
Added RST synchronizer (CW_RST_SYNC.v)

### DIFF
--- a/files/sources/CW_RST_SYNC.v
+++ b/files/sources/CW_RST_SYNC.v
@@ -1,0 +1,49 @@
+`timescale 1ns / 1ps
+//////////////////////////////////////////////////////////////////////////////////
+// Company: 
+// Engineer: Kudryashov D.S.
+// 
+// Create Date: 27.04.2026 11:36:50
+// Design Name: 
+// Module Name: CW_RST_SYNC
+// Project Name: 
+// Target Devices: 
+// Tool Versions: 
+// Description: RST synchronizer
+// 
+// Dependencies: 
+// 
+// Revision:
+// Revision 0.01 - File Created
+// Additional Comments:
+// 
+//////////////////////////////////////////////////////////////////////////////////
+
+
+module CW_RST_SYNC
+(
+    input  wire CLK,
+    input  wire SYS_NRST,
+    output reg  RST
+);
+
+    //---------------> initial
+    reg RST_SYNC;
+    
+    initial begin
+        RST      = 1'b0;
+        RST_SYNC = 1'b0;
+    end
+    
+    //---------------> sequential logic
+    always @(posedge CLK, negedge SYS_NRST) begin
+        if (!SYS_NRST) begin
+            RST      <= 1'b1;
+            RST_SYNC <= 1'b1;
+        end else begin
+            RST_SYNC <= 1'b0;
+            RST      <= RST_SYNC;
+        end
+    end
+    
+endmodule


### PR DESCRIPTION
Добавил логику синхронизатора сброса. Код следует из схемотического представления подключения кнопок RST:

<img width="290" height="147" alt="image" src="https://github.com/user-attachments/assets/24274ef6-8464-4e48-9aba-04015bfe7680" />
Картинка взята из sch на nexus, но так производится вроде на всех платах от xilinx